### PR TITLE
Feat: Add the function of selectable text in the conversation box

### DIFF
--- a/lib/page/ChatPage.dart
+++ b/lib/page/ChatPage.dart
@@ -447,7 +447,7 @@ class _ChatPageState extends State<ChatPage> {
                 data: '$defaultTextPrefix${message['content']}',
                 // data: 'This is a line\nThis is another line'.replaceAll('\n', '<br>'),
                 shrinkWrap: true,
-                selectable: false,
+                selectable: true,
                 styleSheet: MarkdownStyleSheet(
                   textScaleFactor: 1.1,
                   textAlign: WrapAlignment.start,


### PR DESCRIPTION
在Flutter ChatGPT应用程序中增加了一个新的功能，现在用户可以在对话框中选择文本，复制或粘贴他们感兴趣的内容。 这个功能是将ChatPage.dart文件中的MarkdownBody widget的selectable属性更改为true实现的。

此修改已在本机安卓模拟器中测试可用。
#4 